### PR TITLE
Use column inserts in psql dump

### DIFF
--- a/.github/workflows/ingest-snapshot.yaml
+++ b/.github/workflows/ingest-snapshot.yaml
@@ -76,7 +76,7 @@ jobs:
         run: |
           echo "$PGHOST:$PGPORT:$PGDATABASE:$PGUSER:$PGPASSWORD" > ~/.pgpass
           chmod 0600 ~/.pgpass
-          pg_dump -h postgres -p 5432 -U glvd glvd > glvd.sql
+          pg_dump --column-inserts -h postgres -p 5432 -U glvd glvd > glvd.sql
 
       - uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
This makes restore slower but it is more compatible. Without this option I could not use the data in testcontainers/spring.

See docs at:
https://www.postgresql.org/docs/current/app-pgdump.html
